### PR TITLE
fix: patch 4 security alerts (medium severity)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "resolutions": {
     "dpdm@^3.12.0": "patch:dpdm@npm%3A3.12.0#./.yarn/patches/dpdm-npm-3.12.0-0dfdd8e3b8.patch",
-    "langsmith": ">=0.4.6",
+    "langsmith": ">=0.5.19",
     "lodash": ">=4.18.1",
     "js-yaml": ">=4.1.1",
     "semver": ">=7.5.2",
@@ -60,7 +60,8 @@
     "glob@^10.3.7": "10.5.0",
     "glob@^10.3.10": "10.5.0",
     "@octokit/plugin-paginate-rest@11.3.1": ">=11.4.1",
-    "brace-expansion@^2.0.1": "2.0.2",
+    "brace-expansion@^2.0.1": "2.0.3",
+    "brace-expansion@^5.0.2": "5.0.5",
     "tmp@^0.0.33": "0.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,13 +1750,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
-  languageName: node
-  linkType: hard
-
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -2344,12 +2337,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+"brace-expansion@npm:2.0.3":
+  version: 2.0.3
+  resolution: "brace-expansion@npm:2.0.3"
   dependencies:
     balanced-match: ^1.0.0
-  checksum: 01dff195e3646bc4b0d27b63d9bab84d2ebc06121ff5013ad6e5356daa5a9d6b60fa26cf73c74797f2dc3fbec112af13578d51f75228c1112b26c790a87b0488
+  checksum: e9dd66caaf0784126e1654f1bc19adb28f3ef86f39f2226f833f7700ec727c141f6cd85eaa47bacf3426beda01c9fbc3a2f28174cf59330dc9b58ffaf9e09d96
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
+  dependencies:
+    balanced-match: ^4.0.2
+  checksum: 4481b7ffa467b34c14e258167dbd8d9485a2d31d03060e8e8b38142dcde32cdc89c8f55b04d3ae7aae9304fa7eac1dfafd602787cf09c019cc45de3bb6950ffc
   languageName: node
   linkType: hard
 
@@ -2360,15 +2362,6 @@ __metadata:
     balanced-match: ^1.0.0
     concat-map: 0.0.1
   checksum: 2de747a5891ea0d3a1946ea1ae26e056a47f7ea8d42a3009e1736ec3a31a5aa69a3c5da59d998426773553afe4c258e5b12d7953b534fa7f2cf12ce92eed4931
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
-  dependencies:
-    balanced-match: ^4.0.2
-  checksum: ded86c0f0b138734110d67437fee52c1f97bc19175644788b1d71afec2d87d405cf05424ce428f88ae3abe8e09e13ee55f2675534b38076ef70e1e583ed75686
   languageName: node
   linkType: hard
 
@@ -2550,7 +2543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.3.0, chalk@npm:^5.6.2":
+"chalk@npm:^5.3.0":
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
   checksum: 4ee2d47a626d79ca27cb5299ecdcce840ef5755e287412536522344db0fc51ca0f6d6433202332c29e2288c6a90a2b31f3bd626bc8c14743b6b6ee28abd3b796
@@ -2775,15 +2768,6 @@ __metadata:
   version: 1.0.11
   resolution: "confusing-browser-globals@npm:1.0.11"
   checksum: 3afc635abd37e566477f610e7978b15753f0e84025c25d49236f1f14d480117185516bdd40d2a2167e6bed8048641a9854964b9c067e3dcdfa6b5d0ad3c3a5ef
-  languageName: node
-  linkType: hard
-
-"console-table-printer@npm:^2.12.1":
-  version: 2.12.1
-  resolution: "console-table-printer@npm:2.12.1"
-  dependencies:
-    simple-wcswidth: ^1.0.1
-  checksum: 4d58fd4f18d3a69f421c9b0ffd44e5b0542677423491199e92c3e5ca0c023a06304a94bcc60f0d2b480a06cdf0720d2f228807f2af127abc8c905e73fcf64363
   languageName: node
   linkType: hard
 
@@ -5596,21 +5580,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"langsmith@npm:>=0.4.6":
-  version: 0.5.7
-  resolution: "langsmith@npm:0.5.7"
+"langsmith@npm:>=0.5.19":
+  version: 0.5.21
+  resolution: "langsmith@npm:0.5.21"
   dependencies:
-    "@types/uuid": ^10.0.0
-    chalk: ^5.6.2
-    console-table-printer: ^2.12.1
-    p-queue: ^6.6.2
-    semver: ^7.6.3
-    uuid: ^10.0.0
+    p-queue: 6.6.2
+    uuid: 10.0.0
   peerDependencies:
     "@opentelemetry/api": "*"
     "@opentelemetry/exporter-trace-otlp-proto": "*"
     "@opentelemetry/sdk-trace-base": "*"
     openai: "*"
+    ws: ">=7"
   peerDependenciesMeta:
     "@opentelemetry/api":
       optional: true
@@ -5620,7 +5601,9 @@ __metadata:
       optional: true
     openai:
       optional: true
-  checksum: 6a130e6bda0e2e94a7e5462a347f168787e56c4fca02defc51bb6d6601a0408c8bae835e0a5bb5d358d184755512ba8d2ca8c023c2ae4e3e60da7d84fca5d37a
+    ws:
+      optional: true
+  checksum: 89f919c2b54f76491c763b398f963da47ee106477ff2644783f3546a8ba75cbad9d9c4a8171fc3e95b76f0f94278b88c4f5734bc0144b03315130e33b1f1948a
   languageName: node
   linkType: hard
 
@@ -6463,7 +6446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-queue@npm:^6.6.2":
+"p-queue@npm:6.6.2, p-queue@npm:^6.6.2":
   version: 6.6.2
   resolution: "p-queue@npm:6.6.2"
   dependencies:
@@ -7412,13 +7395,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-wcswidth@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "simple-wcswidth@npm:1.0.1"
-  checksum: dc5bf4cb131d9c386825d1355add2b1ecc408b37dc2c2334edd7a1a4c9f527e6b594dedcdbf6d949bce2740c3a332e39af1183072a2d068e40d9e9146067a37f
-  languageName: node
-  linkType: hard
-
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -8226,7 +8202,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^10.0.0":
+"uuid@npm:10.0.0, uuid@npm:^10.0.0":
   version: 10.0.0
   resolution: "uuid@npm:10.0.0"
   bin:


### PR DESCRIPTION
## Security Alert Patch

Resolves 4 Dependabot security alerts in the medium severity tier.

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| `langsmith` | resolution `>=0.4.6` (→0.5.7) | `>=0.5.19` (→0.5.21) | C (resolution bump) | dev-only | GHSA-rr7j-v2q5-chgv, CVE-2026-40190 / GHSA-fw9q-39r9-c252 |
| `brace-expansion@^2.0.1` | resolution pinned `2.0.2` | `2.0.3` | C (resolution bump) | dev-only | CVE-2026-33750 / GHSA-f886-m6hf-6m8v |
| `brace-expansion@^5.0.2` | unpinned (→5.0.4) | new resolution `5.0.5` | C (add resolution) | dev-only | CVE-2026-33750 / GHSA-f886-m6hf-6m8v |

**Strategy** = resolution bump (C). Appropriate here because the root workspace is `private: true` (not published) and the only published workspace package (`libs/langchain-azure` @ 0.0.0) does not depend on `langsmith` or `brace-expansion`. All vulnerable packages are reached only through dev/build tooling.

### Upstream Issues

None — all patched versions are available upstream.

### CVE Details

- [GHSA-rr7j-v2q5-chgv](https://github.com/advisories/GHSA-rr7j-v2q5-chgv) — LangSmith SDK: Streaming token events bypass output redaction (alert #54)
- [CVE-2026-40190 / GHSA-fw9q-39r9-c252](https://github.com/advisories/GHSA-fw9q-39r9-c252) — LangSmith Client SDKs prototype pollution via incomplete `__proto__` guard in internal lodash `set()` (alert #51)
- [CVE-2026-33750 / GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) — brace-expansion zero-step sequence causes process hang and memory exhaustion (alerts #44 and #45)

### Linear Tickets

No matching Linear tickets found.

### Verification

- [x] All lockfiles regenerated (`yarn.lock`)
- [x] Linters pass (`yarn lint`)
- [x] Formatter clean (`yarn format:check`)
- [x] Tests pass (`yarn test:unit` — 3 suites, 3 tests)

🤖 Submitted by langster-patch